### PR TITLE
adding check to look for runner in the same namespace as the engine

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,0 +1,23 @@
+# Configuration for probot-auto-merge - https://github.com/bobvanderlinden/probot-auto-merge
+
+reportStatus: true
+updateBranch: false
+deleteBranchAfterMerge: true
+mergeMethod: squash
+
+minApprovals:
+  COLLABORATOR: 0
+maxRequestedChanges:
+  NONE: 0
+blockingLabels:
+- DO NOT MERGE
+- WIP
+- blocked
+
+# Will merge whenever the above conditions are met, but also
+# the owner has approved or merge label was added.
+rules:
+- minApprovals:
+    OWNER: 1
+- requiredLabels:
+  - merge

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Build Docker Image
         env:
           DOCKER_REPO: ${{ env.REPONAME }}
-          DOCKER_IMAGE: go-runner
+          DOCKER_IMAGE: ${{ env.IMAGENAME }}
           DOCKER_TAG: ${{ env.IMAGETAG }}
         run: |
           make build
@@ -62,7 +62,7 @@ jobs:
       - name: Push Docker Image
         env:
           DOCKER_REPO: ${{ env.REPONAME }}
-          DOCKER_IMAGE: go-runner
+          DOCKER_IMAGE: ${{ env.IMAGENAME }}
           DOCKER_TAG: ${{ env.IMAGETAG }}
         run: |
           make push

--- a/.github/workflows/run-e2e-on-pr-commits.yml
+++ b/.github/workflows/run-e2e-on-pr-commits.yml
@@ -1,5 +1,6 @@
 name: E2E-chaos-ci-lib
 on:
+  workflow_dispatch:
   pull_request:
     branches: [master]
     types: [opened, synchronize, reopened]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing to Chaos-CI-Lib
+
+Chaos-CI-Lib is an Apache 2.0 Licensed project and uses the standard GitHub pull requests process to review and accept contributions.
+
+There are several areas of Litmus that could use your help. For starters, you could help in improving the sections in this document by either creating a new issue describing the improvement or submitting a pull request to this repository. 
+
+-   If you are a first-time contributor, please see [Steps to Contribute](#steps-to-contribute).
+-   If you would like to suggest new tests to be integrated to chaos-ci-lib, please go ahead and [create a new issue](https://github.com/litmuschaos/chaos-ci-lib/issues/new) describing your integration. All you need to do is  specify the workload type and the operations that you would like to perform on the workload.
+-   If you would like to work on something more involved, please connect with the Litmus Contributors. 
+-   If you would like to make code contributions, all your commits should be signed with Developer Certificate of Origin. See [Sign your work](#sign-your-work). 
+
+## Steps to Contribute
+
+-   Find an issue to work on or create a new issue. The issues are maintained at [litmuschaos/chaos-ci-lib](https://github.com/litmuschaos/chaos-ci-lib/issues). You can pick up from a list of [good-first-issues](https://github.com/litmuschaos/chaos-ci-lib/labels/good%20first%20issue).
+-   Claim your issue by commenting your intent to work on it to avoid duplication of efforts. 
+-   Fork the repository on GitHub.
+-   Create a branch from where you want to base your work (usually master).
+-   Make your changes.
+-   Relevant coding style guidelines are the [Go Code Review Comments](https://code.google.com/p/go-wiki/wiki/CodeReviewComments) and the _Formatting and style_ section of Peter Bourgon's [Go: Best Practices for Production Environments](http://peter.bourgon.org/go-in-production/#formatting-and-style).
+-   Commit your changes by making sure the commit messages convey the need and notes about the commit.
+-   Push your changes to the branch in your fork of the repository.
+-   Submit a pull request to the original repository. See [Pull Request checklist](#pull-request-checklist)
+
+## Pull Request Checklist
+
+-   Rebase to the current master branch before submitting your pull request.
+-   Commits should be as small as possible. Each commit should follow the checklist below:
+    -   For code changes, add tests relevant to the fixed bug or new feature
+    -   Pass the compile and tests - includes spell checks, formatting, etc
+    -   Commit header (first line) should convey what changed
+    -   Commit body should include details such as why the changes are required and how the proposed  changes
+    -   DCO Signed
+  
+-   If your PR is not getting reviewed or you need a specific person to review it, please reach out to the Litmus contributors at the [Litmus slack channel](https://app.slack.com/client/T09NY5SBT/CNXNB0ZTN)
+
+## Sign your work
+
+We use the Developer Certificate of Origin (DCO) as an additional safeguard for the LitmusChaos project. This is a well established and widely used mechanism to assure that contributors have confirmed their right to license their contribution under the project's license. Please add a line to every git commit message:
+
+  ```sh
+  Signed-off-by: Random J Developer <random@developer.example.org>
+  ```
+
+Use your real name (sorry, no pseudonyms or anonymous contributions). The email id should match the email id provided in your GitHub profile. 
+If you set your `user.name` and `user.email` in git config, you can sign your commit automatically with `git commit -s`. 
+
+You can also use git [aliases](https://git-scm.com/book/tr/v2/Git-Basics-Git-Aliases) like `git config --global alias.ci 'commit -s'`. Now you can commit with `git ci` and the commit will be signed.
+
+## Setting up your Development Environment
+
+This project is implemented using Go and uses the standard golang tools for development and build. In addition, this project heavily relies on Docker and Kubernetes. It is expected that the contributors.
+    
+-   are familiar with working with Go
+-   are familiar with Docker containers
+-   are familiar with Kubernetes and have access to a Kubernetes cluster or Minikube to test the changes.
+
+## Community
+
+The litmus community will have a monthly community sync-up on 3rd Wednesday 22.00-23.00IST / 18.30-19.30CEST
+-  The community meeting details are available [here](https://hackmd.io/a4Zu_sH4TZGeih-xCimi3Q). Please feel free to join the community meeting.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
-# LitmusChaos CI Lib
+# Chaos CI Lib
+
+[![Slack Channel](https://img.shields.io/badge/Slack-Join-purple)](https://slack.litmuschaos.io)
+![GitHub Workflow](https://github.com/litmuschaos/chaos-ci-lib/actions/workflows/push.yml/badge.svg?branch=master)
+[![Docker Pulls](https://img.shields.io/docker/pulls/litmuschaos/chaos-ci-lib.svg)](https://hub.docker.com/r/litmuschaos/chaos-ci-lib)
+[![GitHub issues](https://img.shields.io/github/issues/litmuschaos/chaos-ci-lib)](https://github.com/litmuschaos/chaos-ci-lib/issues)
+[![Twitter Follow](https://img.shields.io/twitter/follow/litmuschaos?style=social)](https://twitter.com/LitmusChaos)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/5297/badge)](https://bestpractices.coreinfrastructure.org/projects/5297)
+[![Go Report Card](https://goreportcard.com/badge/github.com/litmuschaos/chaos-ci-lib)](https://goreportcard.com/report/github.com/litmuschaos/chaos-ci-lib)
+[![YouTube Channel](https://img.shields.io/badge/YouTube-Subscribe-red)](https://www.youtube.com/channel/UCa57PMqmz_j0wnteRa9nCaw)
+<br><br>
 
 Chaos CI Lib is a central repository which contains different GO bdd tests implemented using the popular Ginkgo, Gomega test framework for running a number of litmuschaos experiments in different CI platforms that can be further used at remote places. The bdd can be used inside the job templates that can be used by the members who are using litmus experiments as part of their CI pipelines.
 
@@ -12,6 +22,10 @@ Litmus supports CI plugin for the following CI platforms:
     <th>Chaos Template </th>
   </tr>
   <tr>
+    <td>GitHub Actions</td>
+    <td><a href="https://github.com/litmuschaos/github-chaos-actions">Click Here</a></td>
+  </tr>  
+  <tr>
     <td>GitLab Remote Templates</td>
     <td><a href="https://github.com/litmuschaos/gitlab-remote-templates">Click Here</a></td>
   </tr>
@@ -20,3 +34,13 @@ Litmus supports CI plugin for the following CI platforms:
     <td><a href="https://github.com/litmuschaos/spinnaker-preconfigured-job-plugin">Click Here</a></td>
   </tr>
 </table>
+
+## How to get started?
+
+Refer the [LitmusChaos Docs](https://docs.litmuschaos.io) and [Experiment Docs](https://litmuschaos.github.io/litmus/experiments/categories/contents/)
+
+## How do I contribute?
+
+You can contribute by raising issues, improving the documentation, contributing to the core framework and tooling, etc.
+
+Head over to the [Contribution guide](CONTRIBUTING.md)

--- a/experiments/container-kill_test.go
+++ b/experiments/container-kill_test.go
@@ -52,7 +52,10 @@ var _ = Describe("BDD of running container-kill experiment", func() {
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+						err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			if err != nil && chaosEngine.Namespace != experimentsDetails.AppNS {
+				err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			}
 			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Chaos pod running status check

--- a/experiments/disk-fill_test.go
+++ b/experiments/disk-fill_test.go
@@ -52,7 +52,10 @@ var _ = Describe("BDD of running disk-fill experiment", func() {
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+						err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			if err != nil && chaosEngine.Namespace != experimentsDetails.AppNS {
+				err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			}
 			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Chaos pod running status check

--- a/experiments/node-cpu-hog_test.go
+++ b/experiments/node-cpu-hog_test.go
@@ -52,7 +52,10 @@ var _ = Describe("BDD of running node-cpu-hog experiment", func() {
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+						err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			if err != nil && chaosEngine.Namespace != experimentsDetails.AppNS {
+				err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			}
 			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Chaos pod running status check

--- a/experiments/node-io-stress_test.go
+++ b/experiments/node-io-stress_test.go
@@ -52,7 +52,10 @@ var _ = Describe("BDD of running node-io-stress experiment", func() {
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+						err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			if err != nil && chaosEngine.Namespace != experimentsDetails.AppNS {
+				err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			}
 			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Chaos pod running status check

--- a/experiments/node-memory-hog_test.go
+++ b/experiments/node-memory-hog_test.go
@@ -52,7 +52,10 @@ var _ = Describe("BDD of running node-memory-hog experiment", func() {
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+						err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			if err != nil && chaosEngine.Namespace != experimentsDetails.AppNS {
+				err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			}
 			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Chaos pod running status check

--- a/experiments/pod-autoscaler_test.go
+++ b/experiments/pod-autoscaler_test.go
@@ -52,7 +52,10 @@ var _ = Describe("BDD of running pod-autoscaler experiment", func() {
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+						err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			if err != nil && chaosEngine.Namespace != experimentsDetails.AppNS {
+				err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			}
 			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Chaos pod running status check

--- a/experiments/pod-cpu-hog_test.go
+++ b/experiments/pod-cpu-hog_test.go
@@ -52,7 +52,10 @@ var _ = Describe("BDD of running pod-cpu-hog experiment", func() {
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+						err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			if err != nil && chaosEngine.Namespace != experimentsDetails.AppNS {
+				err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			}
 			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Chaos pod running status check

--- a/experiments/pod-delete_test.go
+++ b/experiments/pod-delete_test.go
@@ -52,7 +52,10 @@ var _ = Describe("BDD of running pod-delete experiment", func() {
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+			err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			if err != nil && chaosEngine.Namespace != experimentsDetails.AppNS {
+				err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			}
 			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Chaos pod running status check

--- a/experiments/pod-memory-hog_test.go
+++ b/experiments/pod-memory-hog_test.go
@@ -52,7 +52,10 @@ var _ = Describe("BDD of running pod-memory-hog experiment", func() {
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+						err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			if err != nil && chaosEngine.Namespace != experimentsDetails.AppNS {
+				err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			}
 			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Chaos pod running status check

--- a/experiments/pod-network-corruption_test.go
+++ b/experiments/pod-network-corruption_test.go
@@ -52,7 +52,10 @@ var _ = Describe("BDD of running pod-network-corruption experiment", func() {
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+						err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			if err != nil && chaosEngine.Namespace != experimentsDetails.AppNS {
+				err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			}
 			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Chaos pod running status check

--- a/experiments/pod-network-duplication_test.go
+++ b/experiments/pod-network-duplication_test.go
@@ -52,7 +52,10 @@ var _ = Describe("BDD of running pod-network-duplication experiment", func() {
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+						err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			if err != nil && chaosEngine.Namespace != experimentsDetails.AppNS {
+				err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			}
 			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Chaos pod running status check

--- a/experiments/pod-network-latency_test.go
+++ b/experiments/pod-network-latency_test.go
@@ -52,7 +52,10 @@ var _ = Describe("BDD of running pod-network-latency experiment", func() {
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+						err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			if err != nil && chaosEngine.Namespace != experimentsDetails.AppNS {
+				err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			}
 			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Chaos pod running status check

--- a/experiments/pod-network-loss_test.go
+++ b/experiments/pod-network-loss_test.go
@@ -52,7 +52,10 @@ var _ = Describe("BDD of running pod-network-loss experiment", func() {
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+						err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			if err != nil && chaosEngine.Namespace != experimentsDetails.AppNS {
+				err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			}
 			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Chaos pod running status check


### PR DESCRIPTION
The operator creates the runner in the same namespace as the engine, so I've added a check based on the engine's namespace. 

Also added a fallback check in the APP_NS for backwards compatibility, as that's the check that was running previously. To ensure this check doesn't break anyone's pipelines who are using APP_NS for the runner (if even possible). 


For context:

https://kubernetes.slack.com/archives/C018C31N2G0/p1658628918420259