### PR TITLE
check for resources in chaos namespace, with APP NS as a backup

### DIFF
--- a/experiments/container-kill_test.go
+++ b/experiments/container-kill_test.go
@@ -52,7 +52,10 @@ var _ = Describe("BDD of running container-kill experiment", func() {
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+			err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			if err != nil && chaosEngine.Namespace != experimentsDetails.AppNS {
+				err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+			}
 			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Chaos pod running status check

--- a/experiments/disk-fill_test.go
+++ b/experiments/disk-fill_test.go
@@ -52,7 +52,10 @@ var _ = Describe("BDD of running disk-fill experiment", func() {
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+			err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			if err != nil && chaosEngine.Namespace != experimentsDetails.AppNS {
+				err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+			}
 			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Chaos pod running status check

--- a/experiments/node-cpu-hog_test.go
+++ b/experiments/node-cpu-hog_test.go
@@ -52,7 +52,10 @@ var _ = Describe("BDD of running node-cpu-hog experiment", func() {
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+			err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			if err != nil && chaosEngine.Namespace != experimentsDetails.AppNS {
+				err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+			}
 			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Chaos pod running status check

--- a/experiments/node-io-stress_test.go
+++ b/experiments/node-io-stress_test.go
@@ -52,7 +52,10 @@ var _ = Describe("BDD of running node-io-stress experiment", func() {
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+			err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			if err != nil && chaosEngine.Namespace != experimentsDetails.AppNS {
+				err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+			}
 			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Chaos pod running status check

--- a/experiments/node-memory-hog_test.go
+++ b/experiments/node-memory-hog_test.go
@@ -52,7 +52,10 @@ var _ = Describe("BDD of running node-memory-hog experiment", func() {
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+			err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			if err != nil && chaosEngine.Namespace != experimentsDetails.AppNS {
+				err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+			}
 			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Chaos pod running status check

--- a/experiments/pod-autoscaler_test.go
+++ b/experiments/pod-autoscaler_test.go
@@ -52,7 +52,10 @@ var _ = Describe("BDD of running pod-autoscaler experiment", func() {
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+			err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			if err != nil && chaosEngine.Namespace != experimentsDetails.AppNS {
+				err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+			}
 			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Chaos pod running status check

--- a/experiments/pod-cpu-hog_test.go
+++ b/experiments/pod-cpu-hog_test.go
@@ -52,7 +52,10 @@ var _ = Describe("BDD of running pod-cpu-hog experiment", func() {
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+			err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			if err != nil && chaosEngine.Namespace != experimentsDetails.AppNS {
+				err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+			}
 			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Chaos pod running status check

--- a/experiments/pod-delete_test.go
+++ b/experiments/pod-delete_test.go
@@ -52,7 +52,10 @@ var _ = Describe("BDD of running pod-delete experiment", func() {
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+			err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			if err != nil && chaosEngine.Namespace != experimentsDetails.AppNS {
+				err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+			}
 			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Chaos pod running status check

--- a/experiments/pod-memory-hog_test.go
+++ b/experiments/pod-memory-hog_test.go
@@ -52,7 +52,10 @@ var _ = Describe("BDD of running pod-memory-hog experiment", func() {
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+			err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			if err != nil && chaosEngine.Namespace != experimentsDetails.AppNS {
+				err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+			}
 			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Chaos pod running status check

--- a/experiments/pod-network-corruption_test.go
+++ b/experiments/pod-network-corruption_test.go
@@ -52,7 +52,10 @@ var _ = Describe("BDD of running pod-network-corruption experiment", func() {
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+			err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			if err != nil && chaosEngine.Namespace != experimentsDetails.AppNS {
+				err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+			}
 			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Chaos pod running status check

--- a/experiments/pod-network-duplication_test.go
+++ b/experiments/pod-network-duplication_test.go
@@ -52,7 +52,10 @@ var _ = Describe("BDD of running pod-network-duplication experiment", func() {
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+			err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			if err != nil && chaosEngine.Namespace != experimentsDetails.AppNS {
+				err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+			}
 			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Chaos pod running status check

--- a/experiments/pod-network-latency_test.go
+++ b/experiments/pod-network-latency_test.go
@@ -52,7 +52,10 @@ var _ = Describe("BDD of running pod-network-latency experiment", func() {
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+			err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			if err != nil && chaosEngine.Namespace != experimentsDetails.AppNS {
+				err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+			}
 			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Chaos pod running status check

--- a/experiments/pod-network-loss_test.go
+++ b/experiments/pod-network-loss_test.go
@@ -52,7 +52,10 @@ var _ = Describe("BDD of running pod-network-loss experiment", func() {
 
 			//Checking runner pod running state
 			By("[Status]: Runner pod running status check")
-			err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+			err = pkg.RunnerPodStatus(&experimentsDetails, chaosEngine.Namespace, clients)
+			if err != nil && chaosEngine.Namespace != experimentsDetails.AppNS {
+				err = pkg.RunnerPodStatus(&experimentsDetails, experimentsDetails.AppNS, clients)
+			}
 			Expect(err).To(BeNil(), "Runner pod status check failed, due to {%v}", err)
 
 			//Chaos pod running status check


### PR DESCRIPTION
The operator creates the runner in the same namespace as the engine, so I've added a check based on the engine's namespace.

Also added a fallback check in the APP_NS for backwards compatibility, as that's the check that was running previously. To ensure this check doesn't break anyone's pipelines who are using APP_NS for the runner (if even possible).

For context:

https://kubernetes.slack.com/archives/C018C31N2G0/p1658628918420259
